### PR TITLE
Add L20n JS plurals support

### DIFF
--- a/mozilla_pootle/assets.py
+++ b/mozilla_pootle/assets.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Pootle contributors.
+#
+# This file is a part of the Pootle project. It is distributed under the GPL3
+# or later license. See the LICENSE file for a copy of the license and the
+# AUTHORS file for copyright and authorship information.
+
+from django_assets import Bundle, register
+
+
+# <Webpack>
+# These are handled by webpack and therefore have no filters applied
+# They're kept here so hash-based cache invalidation can be used
+
+js_vendor = Bundle(
+    'js/mozilla_pootle/app.bundle.js',
+    output='js/mozilla_pootle_app.min.%(version)s.js')
+register('js_mozilla_pootle', js_vendor)
+
+

--- a/mozilla_pootle/static/js/addFormat.js
+++ b/mozilla_pootle/static/js/addFormat.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+
+function loadL20nFormatAdaptor(props, onLoad) {
+  require.ensure(['editor/formats/l20n/L20nAdapror.js'], (require) => {
+    const adaptor = require('editor/formats/l20n/L20nAdapror.js');
+    onLoad(props, adaptor.default);
+  }); 
+}
+
+export function getFormats() {
+  return {
+    ftl: loadL20nFormatAdaptor,
+    l20n: loadL20nFormatAdaptor,
+  };
+}

--- a/mozilla_pootle/static/js/editor/addFormats.js
+++ b/mozilla_pootle/static/js/editor/addFormats.js
@@ -8,15 +8,15 @@
 
 
 function loadL20nFormatAdaptor(props, onLoad) {
-  require.ensure(['editor/formats/l20n/L20nAdapror.js'], (require) => {
-    const adaptor = require('editor/formats/l20n/L20nAdapror.js');
+  require.ensure(['./formats/l20n/L20nAdaptor.js'], (require) => {
+    const adaptor = require('./formats/l20n/L20nAdaptor.js');
     onLoad(props, adaptor.default);
   }); 
 }
 
-export function getFormats() {
-  return {
+export function addFormats() {
+  PTL.editor.addFormats({
     ftl: loadL20nFormatAdaptor,
     l20n: loadL20nFormatAdaptor,
-  };
+  });
 }

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nAdaptor.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nAdaptor.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import L20nEditorContainer from './L20nEditorContainer';
+import L20nSource from './L20nSource';
+
+
+const L20nAdaptor = {
+  editorComponent: L20nEditorContainer,
+  unitSourceComponent: L20nSource,
+};
+
+
+export default L20nAdaptor;

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nCodeMirror.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nCodeMirror.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+import CodeMirror from '../../../shared/components/CodeMirror';
+
+
+const L20nCodeMirror = React.createClass({
+  displayName: 'L20nCodeMirror',
+
+  render() {
+    return (
+      <CodeMirror
+        markup="javascript"
+        {...this.state}
+        {...this.props}
+      />
+    );
+  },
+});
+
+
+export default L20nCodeMirror;

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nCodeMirror.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nCodeMirror.js
@@ -8,7 +8,7 @@
 
 import React from 'react';
 
-import CodeMirror from '../../../shared/components/CodeMirror';
+import CodeMirror from 'pootle/shared/components/CodeMirror';
 
 
 const L20nCodeMirror = React.createClass({
@@ -17,7 +17,7 @@ const L20nCodeMirror = React.createClass({
   render() {
     return (
       <CodeMirror
-        markup="javascript"
+        markup="htmlmixed"
         {...this.state}
         {...this.props}
       />

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nEditorContainer.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nEditorContainer.js
@@ -8,11 +8,11 @@
 
 import React from 'react';
 
-import { t } from 'utils/i18n';
-import { qAll } from 'utils/dom';
+import { t } from 'pootle/shared/utils/i18n';
+import { qAll } from 'pootle/shared/utils/dom';
 
-import Editor from '../../components/Editor';
-import RawFontTextarea from '../../components/RawFontTextarea';
+import Editor from 'pootle/editor/components/Editor';
+import RawFontTextarea from 'pootle/editor/components/RawFontTextarea';
 
 import L20nCodeMirror from './L20nCodeMirror';
 

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nEditorContainer.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nEditorContainer.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+import { t } from 'utils/i18n';
+import { qAll } from 'utils/dom';
+
+import Editor from '../../components/Editor';
+import RawFontTextarea from '../../components/RawFontTextarea';
+
+import L20nCodeMirror from './L20nCodeMirror';
+
+import {
+  dumpL20nPlurals,
+  dumpL20nValue,
+  getL20nEmptyPluralsEntity,
+  getL20nData,
+} from './utils';
+
+
+const L20nEditorContainer = React.createClass({
+
+  propTypes: {
+    currentLocaleCode: React.PropTypes.string.isRequired,
+    currentLocaleDir: React.PropTypes.string.isRequired,
+
+    initialValues: React.PropTypes.array,
+    isDisabled: React.PropTypes.bool,
+    isRawMode: React.PropTypes.bool,
+    // FIXME: needed to allow interaction from the outside world. Remove ASAP.
+    onChange: React.PropTypes.func.isRequired,
+    sourceValues: React.PropTypes.array,
+    style: React.PropTypes.object,
+    targetNplurals: React.PropTypes.number.isRequired,
+    textareaComponent: React.PropTypes.func,
+    editorComponent: React.PropTypes.func,
+  },
+
+  // FIXME: move context to a higher-order component. It _cannot_ be done now
+  // because we need to access the component's state in a quite hackish and
+  // undesired way, and wrapping the component in a context provider would
+  // prevent us from doing so.
+  childContextTypes: {
+    currentLocaleCode: React.PropTypes.string,
+    currentLocaleDir: React.PropTypes.string,
+  },
+
+  getDefaultProps() {
+    return {
+      initialValues: [],
+      textareaComponent: RawFontTextarea,
+      editorComponent: Editor,
+    };
+  },
+
+  getInitialState() {
+    return {
+      hasL20nPlurals: false,
+      isRichModeEnabled: false,
+      values: this.props.initialValues,
+      l20nValues: this.props.initialValues,
+    };
+  },
+
+  getChildContext() {
+    return {
+      currentLocaleCode: this.props.currentLocaleCode,
+      currentLocaleDir: this.props.currentLocaleDir,
+    };
+  },
+
+  componentWillMount() {
+    const l20nData = getL20nData(
+      this.props.initialValues,
+      this.props.targetNplurals
+    );
+    if (l20nData.isEmpty) {
+      const l20nSourceData = getL20nData(
+        this.props.sourceValues,
+        this.props.sourceValues.length
+      );
+      if (l20nSourceData.hasL20nPlurals) {
+        const l20nEmptyEntity = getL20nEmptyPluralsEntity(this.props.currentLocaleCode);
+        this.l20nUnitEntity = l20nEmptyEntity.unitEntity;
+        this.l20nInitialValues = new Array(l20nEmptyEntity.pluralForms.length).fill('');
+        this.pluralForms = l20nEmptyEntity.pluralForms;
+
+        this.setState({
+          hasL20nPlurals: true,
+          l20nValues: this.l20nInitialValues,
+        });
+      } else if (!l20nSourceData.hasSimpleValue) {
+        this.setState({
+          isRichModeEnabled: true,
+        });
+      }
+    } else if (l20nData.hasL20nPlurals) {
+      this.l20nUnitEntity = l20nData.unitEntity;
+      this.l20nInitialValues = l20nData.unitValues;
+      this.pluralForms = l20nData.pluralForms;
+
+      this.setState({
+        hasL20nPlurals: true,
+        l20nValues: this.l20nInitialValues,
+      });
+    } else if (l20nData.hasSimpleValue) {
+      this.l20nInitialValues = l20nData.unitValues;
+      this.setState({
+        l20nValues: l20nData.unitValues,
+      });
+    } else {
+      this.setState({
+        isRichModeEnabled: true,
+      });
+    }
+  },
+
+  componentDidMount() {
+    this.areas = qAll('.js-translation-area');
+  },
+
+  getAreas() {
+    return this.areas;
+  },
+
+  getPluralFormName(index) {
+    if (this.state.hasL20nPlurals
+        && this.l20nInitialValues.length === this.pluralForms.length) {
+      return t('Plural form [%(name)s]', { name: this.pluralForms[index] });
+    }
+    return '';
+  },
+
+  getStateValues() {
+    return this.state.values;
+  },
+
+  handleChange(i, value) {
+    const newValues = this.state.l20nValues.slice();
+    newValues[i] = value;
+
+    if (this.state.hasL20nPlurals && !this.state.isRichModeEnabled) {
+      try {
+        this.setState({
+          values: dumpL20nPlurals(newValues, this.l20nUnitEntity),
+          l20nValues: newValues,
+        }, this.props.onChange);
+      } catch (e) {
+        if (e.name === 'L20nEditorError') {
+          this.setState({ l20nValues: newValues });
+        } else {
+          throw e;
+        }
+      }
+    } else {
+      let newStateValue = value;
+      if (!this.state.isRichModeEnabled) {
+        newStateValue = dumpL20nValue(value);
+      }
+      this.setState({
+        values: [newStateValue],
+        l20nValues: [value],
+      }, this.props.onChange);
+    }
+  },
+
+  render() {
+    const targetNplurals = this.state.hasL20nPlurals ? this.l20nInitialValues.length : 1;
+    const textareaComponent = this.state.isRichModeEnabled ? L20nCodeMirror
+                                                           : this.props.textareaComponent;
+    return (
+      <this.props.editorComponent
+        getPluralFormName={this.getPluralFormName}
+        hasL20nPlurals={this.state.hasL20nPlurals}
+        initialValues={this.l20nInitialValues}
+        isDisabled={this.props.isDisabled}
+        isRawMode={this.props.isRawMode}
+        isRichModeEnabled={this.state.isRichModeEnabled}
+        onChange={this.handleChange}
+        sourceValues={this.props.sourceValues}
+        style={this.props.style}
+        targetNplurals={targetNplurals}
+        textareaComponent={textareaComponent}
+        values={this.state.l20nValues}
+      />
+    );
+  },
+
+});
+
+
+export default L20nEditorContainer;

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nSource.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nSource.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import React from 'react';
+
+import { t } from 'utils/i18n';
+
+import UnitSource from '../../components/UnitSource';
+import { getL20nData } from './utils';
+
+
+const InnerPre = ({ sourceValue }) => (
+  <pre
+    dangerouslySetInnerHTML={
+      { __html: sourceValue }
+    }
+  />
+);
+
+InnerPre.propTypes = {
+  sourceValue: React.PropTypes.string.isRequired,
+};
+
+
+const L20nSource = React.createClass({
+
+  propTypes: {
+    values: React.PropTypes.array.isRequired,
+    sourceLocaleCode: React.PropTypes.string,
+  },
+
+  getInitialState() {
+    return {
+      values: this.props.values,
+      isRichModeEnabled: false,
+    };
+  },
+
+  componentWillMount() {
+    const l20nData = getL20nData(this.props.values);
+
+    if (l20nData.hasL20nPlurals) {
+      this.setState({
+        values: l20nData.unitValues,
+        pluralForms: l20nData.pluralForms,
+        hasPlurals: true,
+      });
+    } else if (l20nData.hasSimpleValue) {
+      this.setState({
+        values: l20nData.unitValues,
+      });
+    } else {
+      this.setState({
+        isRichModeEnabled: true,
+      });
+    }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.enableRichMode) {
+      this.setState({
+        values: nextProps.values,
+        hasPlurals: nextProps.values.length > 1,
+        isRichModeEnabled: true,
+      });
+    } else {
+      const l20nData = getL20nData(nextProps.values);
+      if (l20nData.hasL20nPlurals) {
+        this.setState({
+          values: l20nData.unitValues,
+          pluralForms: l20nData.pluralForms,
+          hasPlurals: true,
+          isRichModeEnabled: false,
+        });
+      } else if (l20nData.hasSimpleValue) {
+        this.setState({
+          values: l20nData.unitValues,
+          isRichModeEnabled: false,
+        });
+      } else {
+        this.setState({
+          isRichModeEnabled: true,
+        });
+      }
+    }
+  },
+
+  getPluralFormName(index) {
+    if (this.state.pluralForms !== undefined &&
+        this.state.pluralForms.length === this.state.values.length) {
+      return t('Plural form [%(key)s]', { key: this.state.pluralForms[index] });
+    }
+    return '';
+  },
+
+  render() {
+    const extraProps = {};
+    if (this.state.isRichModeEnabled) {
+      extraProps.innerComponent = InnerPre;
+    }
+    return (
+      <UnitSource
+        {...this.props}
+        {...this.state }
+        {...extraProps}
+        getPluralFormName={this.getPluralFormName}
+      />
+    );
+  },
+});
+
+
+export default L20nSource;

--- a/mozilla_pootle/static/js/editor/formats/l20n/L20nSource.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/L20nSource.js
@@ -8,9 +8,9 @@
 
 import React from 'react';
 
-import { t } from 'utils/i18n';
+import { t } from 'pootle/shared/utils/i18n';
 
-import UnitSource from '../../components/UnitSource';
+import UnitSource from 'pootle/editor/components/UnitSource';
 import { getL20nData } from './utils';
 
 

--- a/mozilla_pootle/static/js/editor/formats/l20n/utils.js
+++ b/mozilla_pootle/static/js/editor/formats/l20n/utils.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import assign from 'object-assign';
+
+import { FTLASTParser, FTLASTSerializer, getPluralForms } from 'l20n';
+
+
+class L20nEditorError extends Error {
+  constructor(message, id) {
+    super();
+    this.name = 'L20nEditorError';
+    this.message = message;
+    this.id = id;
+  }
+}
+
+
+function getTextElementL20nEntity(value) {
+  const textElementResource = FTLASTParser.parseResource('unit = value');
+  textElementResource[0].body[0].value.elements[0].value = value;
+
+  return textElementResource[0].body[0];
+}
+
+
+function parseL20nValue(value) {
+  try {
+    const unitEntity = FTLASTParser.parseResource(`unit = ${value}`)[0].body[0];
+    return { unitEntity, error: null };
+  } catch (e) {
+    if (e.name === 'L10nError') {
+      return { unitEntity: null, error: e };
+    }
+    throw e;
+  }
+}
+
+
+function setL20nPlurals(data) {
+  const value = data.unitEntity.value;
+  const hasL20nPlurals = (value !== undefined &&
+                          value.elements.length === 1 &&
+                          value.elements[0].type === 'Placeable' &&
+                          value.elements[0].expressions[0].type === 'SelectExpression' &&
+                          value.elements[0].expressions[0].expression.callee.name === 'PLURAL');
+  assign(data, { hasL20nPlurals });
+  if (hasL20nPlurals) {
+    const unitValues = [];
+    const pluralForms = [];
+    const variants = data.unitEntity.value.elements[0].expressions[0].variants;
+    for (let i = 0; i < variants.length; i++) {
+      unitValues.push(variants[i].value.source);
+      let key = FTLASTSerializer.dumpExpression(variants[i].key);
+      if (variants[i].default) {
+        key = `${key}, default`;
+      }
+      pluralForms.push(key);
+    }
+    assign(data, { unitValues, pluralForms });
+  }
+  return hasL20nPlurals;
+}
+
+
+function setSimpleValue(data) {
+  const value = data.unitEntity.value;
+  const hasSimpleValue = (value !== undefined &&
+                    value.elements.length === 1 &&
+                    value.elements[0].type === 'TextElement');
+
+  if (hasSimpleValue) {
+    assign(data, { unitValues: [value.source] });
+  }
+  assign(data, { hasSimpleValue });
+  return hasSimpleValue;
+}
+
+
+export function getL20nData(values, nplurals) {
+  if (nplurals !== undefined && nplurals !== 1 || values.length !== 1 || values[0] === '') {
+    return { isEmpty: true };
+  }
+  const result = parseL20nValue(values[0]);
+  if (result.error !== null) {
+    return result;
+  }
+
+  if (setL20nPlurals(result)) {
+    return result;
+  }
+
+  setSimpleValue(result);
+
+  return result;
+}
+
+
+export function dumpL20nPlurals(values, l20nUnitEntity) {
+  const variants = l20nUnitEntity.value.elements[0].expressions[0].variants;
+
+  if (values.every(value => value === '')) {
+    return '';
+  } else if (values.some(value => value === '')) {
+    throw new L20nEditorError('All plural forms should be filled.');
+  }
+  for (let i = 0; i < values.length; i++) {
+    const textElementEntity = getTextElementL20nEntity(values[i]);
+    variants[i].value = textElementEntity.value;
+  }
+
+  try {
+    return [FTLASTSerializer.dumpPattern(l20nUnitEntity.value)];
+  } catch (e) {
+    throw new L20nEditorError(e.message);
+  }
+}
+
+
+export function dumpL20nValue(value) {
+  const l20nUnitEntity = getTextElementL20nEntity(value);
+
+  try {
+    return FTLASTSerializer.dumpPattern(l20nUnitEntity.value);
+  } catch (e) {
+    throw new L20nEditorError(e.message);
+  }
+}
+
+
+export function getL20nEmptyPluralsEntity(localeCode) {
+  const pluralForms = getPluralForms(localeCode);
+  const pluralFormsPattern = pluralForms.map((x) => `[${x}] val`).join('\n');
+  const unit = `unit = { PLURAL($num) -> \n ${pluralFormsPattern} \n}`;
+  const unitEntity = FTLASTParser.parseResource(unit)[0].body[0];
+  return { unitEntity, pluralForms };
+}
+
+
+export { L20nEditorError as L20nEditorError };

--- a/mozilla_pootle/static/js/index.js
+++ b/mozilla_pootle/static/js/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) Pootle contributors.
+ *
+ * This file is a part of the Pootle project. It is distributed under the GPL3
+ * or later license. See the LICENSE file for a copy of the license and the
+ * AUTHORS file for copyright and authorship information.
+ */
+
+import { addFormats } from './editor/addFormats';
+
+PTL.mozilla_pootle = {
+  init() {
+    addFormats();    
+  }
+};
+

--- a/mozilla_pootle/static/js/manifest.json
+++ b/mozilla_pootle/static/js/manifest.json
@@ -1,0 +1,4 @@
+{
+     "editor": ["addFormat.js"],
+     "l20nAdaptor": ["editor/formats/l20n/L20nAdaptor.js"],
+}

--- a/mozilla_pootle/static/js/manifest.json
+++ b/mozilla_pootle/static/js/manifest.json
@@ -1,4 +1,3 @@
 {
-     "editor": ["addFormat.js"],
-     "l20nAdaptor": ["editor/formats/l20n/L20nAdaptor.js"],
+     "mozilla_pootle": ["index.js"]
 }

--- a/mozilla_pootle/static/js/package.json
+++ b/mozilla_pootle/static/js/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mozilla-pootle",
+  "version": "0.0.0",
+  "license": "GPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/translate/mozilla-pootle.git"
+  },
+  "scripts": {
+    "lint": "eslint .",
+    "stylelint": "stylelint --config=stylelint.json ../css/**/*.css **/*.css",
+    "test": "mocha --compilers js:babel-register \"./{,!(node_modules)/**/}*.test.js\""
+  },
+  "devDependencies": {
+    "babel-polyfill": "^6.13.0"
+  },
+  "dependencies": {
+    "fs": "^0.0.2",
+    "l20n": "https://github.com/ta2-1/l20n.js.git#get_all_plural_forms"
+  }
+}
+

--- a/mozilla_pootle/templates/editor/_scripts.html
+++ b/mozilla_pootle/templates/editor/_scripts.html
@@ -1,0 +1,46 @@
+{% load assets store_tags %}
+<script id="view_unit" type="text/template">
+{% include_raw "editor/units/xhr_view.html" %}
+</script>
+<script id="tm_suggestions" type="text/template">
+{% include_raw "editor/units/xhr_tm.html" %}
+</script>
+<script id="editCtx" type="text/template">
+{% include_raw "editor/units/xhr_edit_ctx.html" %}
+</script>
+<script id="js-editor-msg" type="text/template">
+{% include_raw "editor/msg.html" %}
+</script>
+{% assets "js_editor" %}
+<script type="text/javascript" src="{{ ASSET_URL }}"></script>
+{% endassets %}
+{% assets "js_mozilla_pootle" %}
+<script type="text/javascript" src="{{ ASSET_URL }}"></script>
+{% endassets %}
+<script type="text/javascript">
+$(function() {
+  var options = {
+    tmUrl: '{{ AMAGAMA_URL }}',
+    pootlePath: '{{ pootle_path }}',
+    vFolder: '{{ current_vfolder_pk }}',
+    ctxPath: '{{ ctx_path }}',
+    resourcePath: '{{ resource_path }}',
+    chunkSize: {{ request.user.get_unit_rows }},
+    displayPriority: {{ display_priority|yesno:"true,false" }},
+    isAdmin: {{ has_admin_access|yesno:"true,false" }},
+    isAnonymous: {{ request.user.is_anonymous|yesno:"true,false" }},
+    userId: {{ request.user.id }},
+    localeDir: '{{ language.direction }}',
+    canReview: {{ canreview|yesno:"true,false" }},
+  };
+  {% if cansuggest or cantranslate %}
+  options.mt = [
+    {% for provider, apikey in POOTLE_MT_BACKENDS %}
+    { name: '{{ provider }}', key: '{{ apikey }}' },
+    {% endfor %}
+  ];
+  {% endif %}
+  PTL.editor.init(options);
+  PTL.mozilla_pootle.init();
+});
+</script>


### PR DESCRIPTION
This PR moves https://github.com/translate/pootle/pull/5224 to this repo. It adds possibility to edit some types of l20n unit in Pootle editor:
- valid l20n plural: Editor displays it as multistring plural unit with custom plural form names;
- empty l20n plural: Editor displays it as empty multistring plural unit with custom plural form names which are received by language code;
- simple value;
- multiline value: Editor hides l20n format for multilines;
- invalid l20n plural: Source is displayed as multistring plural, Editor drops to rich mode;
- invalid l20n source: Source is displayed as L20n formatted value, Editor drops to rich mode;

View rows, suggestions and timeline rows are still displayed in raw l20n format. It was not focus of this PR and will be fixed in the next ones.
